### PR TITLE
[conversionArea]セレクトボックス 横幅修正

### DIFF
--- a/assets/tmpl/moc/customer/register/index.pug
+++ b/assets/tmpl/moc/customer/register/index.pug
@@ -207,7 +207,7 @@ block conversionArea
                             span 会員マスター
                 .col-6
                     .row.align-items-center.justify-content-end
-                        .col-2
+                        .col-auto
                             form
                                 select.form-control
                                     option(value='') 本会員

--- a/assets/tmpl/moc/product/register/index.pug
+++ b/assets/tmpl/moc/product/register/index.pug
@@ -338,7 +338,7 @@ block conversionArea
                             span 商品マスター
                 .col-6
                     .row.align-items-center.justify-content-end
-                        .col-2
+                        .col-auto
                             form
                                 select.form-control
                                     option(value='') 公開

--- a/assets/tmpl/moc/product/register/standard/index.pug
+++ b/assets/tmpl/moc/product/register/standard/index.pug
@@ -107,7 +107,7 @@ block conversionArea
                             span 商品マスター
                 .col-6
                     .row.align-items-center.justify-content-end
-                        .col-2
+                        .col-auto
                             form
                                 select.form-control
                                     option(value='') 公開

--- a/assets/tmpl/moc/shipment/register/index.pug
+++ b/assets/tmpl/moc/shipment/register/index.pug
@@ -220,11 +220,11 @@ block conversionArea
                             span 出荷マスター
                 .col-6
                     .row.align-items-center.justify-content-end
-                        .col-2
+                        .col-auto
                             form
                                 select.form-control
+                                    option(value='') 出荷
                                     option(value='') 未出荷
-                                    option(value='') ...
                         .col-auto
                             button.btn.btn-ec-conversion.px-4(data-toggle="modal" data-target="#registerShipment") 出荷情報を登録
     #registerShipment.modal.fade(tabindex='-1', role='dialog', aria-labelledby='registerShipment', aria-hidden='true')


### PR DESCRIPTION
issue #53 
（↑mikakaneリポジトリのissue番号です。）

画面下(conversionArea)のセレクトボックスの横幅を「col-2」->「col-auto」に修正
[出荷登録]出荷、未出荷の選択ができるように修正