### PR TITLE
[ホーム][チュートリアル完了] リンク設定 tooltip削除

### DIFF
--- a/assets/tmpl/moc/index.pug
+++ b/assets/tmpl/moc/index.pug
@@ -40,7 +40,7 @@ block primaryContents
                     span.font-weight-bold.align-middle 特定商取引法に関する表記を設定しましょう
                     p 商品マスターに最初の商品を登録してみましょう。商品の画像を用意してください。
                 .col-2.text-right.align-middle
-                    a(href="").btn.btn-ec-conversion.px-4 設定する
+                    a(href="/setting/basis/shop").btn.btn-ec-conversion.px-4 設定する
             .row.border.border-top-0.border-left-0.border-right-0.p-3.align-items-center
                 .col-1.align-middle.text-center
                     i.fa.fa-cubes.fa-4x.text-secondary(aria-hidden='true')
@@ -61,9 +61,8 @@ block primaryContents
         .col-4.mb-4
             .card.rounded.border-0.h-100
                 .card-header
-                    .d-inline-block(data-toggle="tooltip" data-placement="top" title="Tooltip")
-                        a(href="/order/master")
-                            span.card-title 受注状況
+                    a(href="/order/master")
+                        span.card-title 受注状況
                 .card-body.p-0
                     .d-block.p-3.border.border-top-0.border-left-0.border-right-0
                         .row.align-items-center

--- a/assets/tmpl/moc/tutorial/complete/index.pug
+++ b/assets/tmpl/moc/tutorial/complete/index.pug
@@ -22,9 +22,8 @@ block primaryContents
         .col-4.mb-4
             .card.rounded.border-0.h-100
                 .card-header
-                    .d-inline-block(data-toggle="tooltip" data-placement="top" title="Tooltip")
-                        a(href="/order/master")
-                            span.card-title 受注状況
+                    a(href="/order/master")
+                        span.card-title 受注状況
                 .card-body.p-0
                     .d-block.p-3.border.border-top-0.border-left-0.border-right-0
                         .row.align-items-center


### PR DESCRIPTION
fixed #92 

- １つめの「設定する」ボタンを`ショップマスターページ`にリンク
- 「受注状況」のtooltipのコードを消す(チュートリアル完了画面も)