### PR TITLE
[商品管理]商品登録 tooltip削除

### DIFF
--- a/assets/tmpl/moc/product/register/index.pug
+++ b/assets/tmpl/moc/product/register/index.pug
@@ -195,9 +195,7 @@ block primaryContents
             .card-body
                 .row
                     .col-3
-                        .d-inline-block(data-toggle="tooltip" data-placement="top" title="Tooltip")
-                            span フリーエリア
-                            i.fa.fa-question-circle.fa-lg.ml-1
+                        span フリーエリア
                     .col-9
                         form
                             textarea(rows="8").form-control
@@ -288,9 +286,7 @@ block secondaryContents
         .card-header
             .row
                 .col-8
-                    .d-inline-block(data-toggle="tooltip" data-placement="top" title="Tooltip")
-                        span.card-title 登録日・更新日
-                            i.fa.fa-question-circle.fa-lg.ml-1
+                    span.card-title 登録日・更新日
                 .col-4.text-right
                     a(data-toggle="collapse" href="#update" aria-expanded="false" aria-controls="update")
                         i.fa.fa-angle-up.fa-lg


### PR DESCRIPTION
fixed #95 

- フリーエリア
- 登録日・更新日

該当箇所のtooltipに関するコードおよび、アイコン削除