### PR TITLE
[商品CSV登録][出荷CSV登録] tooltip削除

### DIFF
--- a/assets/tmpl/moc/product/csv/product/index.pug
+++ b/assets/tmpl/moc/product/csv/product/index.pug
@@ -12,7 +12,6 @@ block primaryContents
             .row
                 .col-2
                         span CSVファイル選択
-                        i.fa.fa-question-circle.fa-lg.ml-1
                 .col
                     form.mb-2
                         a(onclick="$('#fileForm').click()").btn.btn-ec-regular.mr-2 ファイルを選択

--- a/assets/tmpl/moc/shipment/csv/shipment/index.pug
+++ b/assets/tmpl/moc/shipment/csv/shipment/index.pug
@@ -13,7 +13,6 @@ block primaryContents
             .row
                 .col-2
                         span CSVファイル選択
-                        i.fa.fa-question-circle.fa-lg.ml-1
                 .col
                     form.mb-2
                         a(onclick="$('#fileForm').click()").btn.btn-ec-regular.mr-2 ファイルを選択


### PR DESCRIPTION
fixed #97 

- 「 CSVファイル選択」のツールチップに関するコードとアイコンを削除

