### PR TITLE
[メール通知] badgeに変更 tooltip削除

### DIFF
--- a/assets/tmpl/moc/order/mail/index.pug
+++ b/assets/tmpl/moc/order/mail/index.pug
@@ -42,8 +42,7 @@ block primaryContents
                     .col-2
                         span 対応状況
                     .col-10
-                        .c-label
-                            span 発送済み
+                        span.badge.badge-ec-glay 発送済み
     .card.rounded.border-0.mb-4
         .card-header
             .row
@@ -337,9 +336,7 @@ block primaryContents
         .card-header
             .row
                 .col-8
-                    .d-inline-block(data-toggle="tooltip" data-placement="top" title="Tooltip")
-                        span.card-title 新規メール配信
-                        i.fa.fa-question-circle.fa-lg.ml-1
+                    span.card-title 新規メール配信
                 .col-4.text-right
                     a(data-toggle="collapse" href="#mailCreate" aria-expanded="false" aria-controls="mailCreate")
                         i.fa.fa-angle-up.fa-lg

--- a/assets/tmpl/moc/shipment/mail/index.pug
+++ b/assets/tmpl/moc/shipment/mail/index.pug
@@ -42,8 +42,7 @@ block primaryContents
                     .col-2
                         span 対応状況
                     .col-10
-                        .c-label
-                            span 発送済み
+                        span.badge.badge-ec-glay 発送済み
     .card.rounded.border-0.mb-4
         .card-header
             .row
@@ -337,9 +336,7 @@ block primaryContents
         .card-header
             .row
                 .col-8
-                    .d-inline-block(data-toggle="tooltip" data-placement="top" title="Tooltip")
-                        span.card-title 新規メール配信
-                        i.fa.fa-question-circle.fa-lg.ml-1
+                    span.card-title 新規メール配信
                 .col-4.text-right
                     a(data-toggle="collapse" href="#mailCreate" aria-expanded="false" aria-controls="mailCreate")
                         i.fa.fa-angle-up.fa-lg


### PR DESCRIPTION
fixed #99 

- 「発送済み」をbadge扱いに変更 
- 新規メール配信のtooltip削除